### PR TITLE
Added Support for softimer

### DIFF
--- a/Client/sdk/ME_TdGame_classes.hpp
+++ b/Client/sdk/ME_TdGame_classes.hpp
@@ -1688,11 +1688,21 @@ public:
 	float                                              LastYAxisTilt;                                            // 0x0688(0x0004)
 	TArray<class USeqEvt_TdWeaponFired*>               WeaponFiredEvents;                                        // 0x068C(0x000C) (NeedCtorLink)
 
-	static UClass* StaticClass()
-	{
-		static auto ptr = UObject::FindClass("Class TdGame.TdPlayerController");
-		return ptr;
-	}
+static UClass *StaticClass() {
+                static auto *ptr = nullptr;
+                
+                if (!ptr) {
+                    ptr = UObject::FindClass("Class MirrorsEdgeTweaksScripts.SofTimerHUDSetup");
+
+                    if (!ptr) {
+                        ptr = UObject::FindClass("Class TdGame.TdPlayerController");
+                    }
+                }
+				
+                //static auto ptr = UObject::FindClass("Class TdGame.SpeedrunPlayerController");
+                return ptr;
+        }
+
 
 
 	void SetUseTiltForwardAndBack(bool bActive);

--- a/Client/sdk/ME_TdGame_classes.hpp
+++ b/Client/sdk/ME_TdGame_classes.hpp
@@ -1699,7 +1699,6 @@ static UClass *StaticClass() {
                     }
                 }
 				
-                //static auto ptr = UObject::FindClass("Class TdGame.SpeedrunPlayerController");
                 return ptr;
         }
 


### PR DESCRIPTION
softimer replaces the "TdGame.TdPlayerController" with "MirrorsEdgeTweaksScripts.SofTimerHUDSetup"

I changed the aTdPlayerController class to first look for the new SofTimerHUDSetup and if it's not found search for the original

there are still incompatibilites with softimer such as it taking longer to connect but I will look into that in the future