### PR TITLE
Improved Softimer support and broader support for D3D.

### DIFF
--- a/Client/main.cpp
+++ b/Client/main.cpp
@@ -11,38 +11,49 @@
 #include "addons/misc.h"
 #include "addons/chaos/chaos.h"
 
+DWORD WINAPI InitThread(LPVOID param) {
+    // Wait for D3D9 to be fully loaded
+    while (!GetModuleHandle(L"d3d9.dll")) {
+        Sleep(100);
+    }
+    
+    Sleep(100);
+
+    Settings::Load();
+
+    Addon *addons[] = { new Client(), new Trainer(), new Dolly(), new Misc(), new Chaos() };
+
+    if (!Engine::Initialize()) {
+        MessageBoxA(nullptr, "Failed to initialize engine", "Fatal", 0);
+        goto CLEANUP;
+    }
+
+    if (!Menu::Initialize()) {
+        MessageBoxA(nullptr, "Failed to initialize menu", "Fatal", 0);
+        goto CLEANUP;
+    }
+    
+    for (auto &addon : addons) {
+        if (!addon->Initialize()) {
+            MessageBoxA(nullptr, ("Failed to initialize \"" + addon->GetName() + "\"").c_str(), "Fatal", 0);
+        }
+    }
+
+    return 0;
+
+    CLEANUP:
+        for (const auto addon: addons) {
+            delete addon;
+        }
+    return 0;
+}
+
 BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID reserved) {
     if (reason == DLL_PROCESS_ATTACH) {
+        DisableThreadLibraryCalls(module);
         Debug::Initialize();
 
-        while (!GetModuleHandle(L"d3d9.dll")) {
-            Sleep(100);
-        }
-
-        Settings::Load();
-
-        Addon *addons[] = { new Client(), new Trainer(), new Dolly(), new Misc(), new Chaos() };
-
-        if (!Engine::Initialize()) {
-            MessageBoxA(nullptr, "Failed to initialize engine", "Fatal", 0);
-            goto CLEANUP;
-        }
-
-        if (!Menu::Initialize()) {
-            MessageBoxA(nullptr, "Failed to initialize menu", "Fatal", 0);
-            goto CLEANUP;
-        }
-		
-        for (auto &addon : addons) {
-            if (!addon->Initialize()) {
-                MessageBoxA(nullptr, ("Failed to initialize \"" + addon->GetName() + "\"").c_str(), "Fatal", 0);
-            }
-        }
-	
-        CLEANUP:
-            for (const auto addon: addons) {
-                delete addon;
-            }
+        CreateThread(nullptr, 0, InitThread, nullptr, 0, nullptr);
     }
-	return TRUE;
+    return TRUE;
 }

--- a/Client/sdk/ME_TdGame_classes.hpp
+++ b/Client/sdk/ME_TdGame_classes.hpp
@@ -1688,17 +1688,30 @@ public:
 	float                                              LastYAxisTilt;                                            // 0x0688(0x0004)
 	TArray<class USeqEvt_TdWeaponFired*>               WeaponFiredEvents;                                        // 0x068C(0x000C) (NeedCtorLink)
 	
+	static bool bNeedSofTimerCheck;
+
 	static UClass *StaticClass() {
 		static UClass *ptr = nullptr;
+		static bool bFoundSofTimer = false;
 
-		if (!ptr) {
-			ptr = UObject::FindClass("Class MirrorsEdgeTweaksScripts.SofTimerHUDSetup");
-
-			if (!ptr) {
-				ptr = UObject::FindClass("Class TdGame.TdPlayerController");
-			}
+		if (bFoundSofTimer) {
+			return ptr;
 		}
 
+		if (bNeedSofTimerCheck) {
+			auto sofPtr = UObject::FindClass("Class MirrorsEdgeTweaksScripts.SofTimerPlayerController");
+			if (sofPtr) {
+				ptr = sofPtr;
+				bFoundSofTimer = true;
+				return ptr;
+			}
+			bNeedSofTimerCheck = false;
+		}
+
+		if (!ptr) {
+			ptr = UObject::FindClass("Class TdGame.TdPlayerController");
+		}
+		
 		return ptr;
 	}
 

--- a/Client/sdk/ME_TdGame_functions.cpp
+++ b/Client/sdk/ME_TdGame_functions.cpp
@@ -12,6 +12,8 @@ namespace Classes
 //Functions
 //---------------------------------------------------------------------------
 
+bool ATdPlayerController::bNeedSofTimerCheck = true;
+
 // Function TdGame.TdCrowdPathNode.CanBeSeenFrom
 // (Native, Public)
 // Parameters:


### PR DESCRIPTION
### Improve Softimer support
- Added dynamic detection to ensure the correct controller class is detected when toggling Softimer on / off - fixes crashing.
- PlayerController class name for Softimer has since been renamed to SofTimerPlayerController (from SofTimerHUDSetup) - updated references in mmultiplayer.

### Support for ReShade, DXVK, etc.
- Replaced the Microsoft .dll pattern scanning with a temporary D3D9 device to retrieve the vtable pointer.
- Implemented multiple CreateDevice fallbacks to bypass D3DERR_DEVICELOST errors caused by third party Direct3D proxies / wrappers.
- Updated main.cpp to move initialisation to a worker thread to avoid DllMain loader deadlocks with Direct3D proxies / wrappers.
